### PR TITLE
Fix the imread path

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ else:
     ext_img = Image.open(path)
 
 ext_img.save("data/target.png", "PNG")
-image = cv.imread("data/target.jpg")
+image = cv.imread("data/target.png")
 
 # Convert resized RGB image to grayscale
 NUM_CHANNELS = 3


### PR DESCRIPTION
Before, the script first saved the converted pdf to `data/target.png`
and then tried to read from `data/target.jpg`. This causes a NoneType error later.